### PR TITLE
Get crate version from the environment

### DIFF
--- a/vrp-cli/src/main.rs
+++ b/vrp-cli/src/main.rs
@@ -15,12 +15,12 @@ mod cli {
     use super::commands::solve::{get_solve_app, run_solve};
     use crate::commands::check::{get_check_app, run_check};
     use crate::commands::generate::{get_generate_app, run_generate};
-    use clap::App;
+    use clap::{crate_version, App};
     use std::process;
 
     pub fn run_app() {
         let matches = App::new("Vehicle Routing Problem Solver")
-            .version("0.1")
+            .version(crate_version!())
             .author("Ilya Builuk <ilya.builuk@gmail.com>")
             .about("A command line interface to Vehicle Routing Problem solver")
             .subcommand(get_solve_app())


### PR DESCRIPTION
When running the CLI it would be nice to see the actual version you are running. [This is something we can get from the environment.](https://github.com/clap-rs/clap/blob/master/examples/09_auto_version.rs) 

<img width="605" alt="Screen Shot 2020-05-03 at 4 40 42 PM" src="https://user-images.githubusercontent.com/14836934/80917071-fd09b180-8d5c-11ea-8a9c-3cabd648c9e4.png">
