### PR TITLE
Print solutions as pragmatic & geojson under json key

### DIFF
--- a/docs/src/examples/interop/javascript.md
+++ b/docs/src/examples/interop/javascript.md
@@ -198,7 +198,7 @@ To test it, use the following index.html file:
             }
         };
 
-        const solution = solve_pragmatic(pragmatic_problem, matrix_data, config);
+        const solution = solve_pragmatic(pragmatic_problem, matrix_data, config, false);
         console.log(`solution is:\n ${solution}`);
     }
 

--- a/examples/jvm-interop/src/main/java/vrp/example/java/Application.java
+++ b/examples/jvm-interop/src/main/java/vrp/example/java/Application.java
@@ -18,6 +18,7 @@ interface Solver extends Library {
     void solve_pragmatic(String problem, String[] matrices,
                          int matricesSize,
                          String config,
+                         boolean geojson,
                          OnSuccess onSuccess, OnError onError);
 }
 
@@ -56,7 +57,7 @@ class Application {
                     }
                 });
 
-        solver.solve_pragmatic(problem, matrices, matrices.length, "{}",
+        solver.solve_pragmatic(problem, matrices, matrices.length, "{}", false
                 new OnSuccess() {
                     @Override
                     public void result(String json) {

--- a/examples/jvm-interop/src/main/kotlin/vrp/example/kotlin/Application.kt
+++ b/examples/jvm-interop/src/main/kotlin/vrp/example/kotlin/Application.kt
@@ -17,6 +17,7 @@ private interface Solver : Library {
                         matrices: Array<String>,
                         matricesLen: Int,
                         config: String,
+                        geojson: Boolean,
                         onSuccess: OnSuccess, onError: OnError)
 }
 
@@ -51,7 +52,7 @@ fun main(args: Array<String>) {
             }
     )
 
-    solver.solve_pragmatic(problem, matrices, matrices.size, "{}",
+    solver.solve_pragmatic(problem, matrices, matrices.size, "{}", false
             onSuccess = object : OnSuccess {
                 override fun result(json: String) {
                     println("solution: $json")

--- a/examples/python-interop/example.py
+++ b/examples/python-interop/example.py
@@ -117,6 +117,7 @@ solution = prg.Solution(**json.loads(vrp_cli.solve_pragmatic(
     problem=json.dumps(problem, default=pydantic_encoder),
     matrices=[json.dumps(matrix, default=pydantic_encoder)],
     config=json.dumps(config, default=pydantic_encoder),
+    False # If True returns { "pragmatic": <...>, "geo": <...> }
 )))
 
 print(solution)

--- a/vrp-cli/tests/unit/lib_test.rs
+++ b/vrp-cli/tests/unit/lib_test.rs
@@ -29,7 +29,7 @@ fn can_get_solution_serialized() {
     };
     let problem = Arc::new(problem.read_pragmatic().unwrap());
 
-    let solution = get_solution_serialized(problem, Config::default()).unwrap().replace([' ', '\n'], "");
+    let solution = get_solution_serialized(problem, Config::default(), false).unwrap().replace([' ', '\n'], "");
 
     assert!(solution.starts_with('{'));
     assert!(solution.ends_with('}'));

--- a/vrp-core/src/construction/enablers/schedule_update.rs
+++ b/vrp-core/src/construction/enablers/schedule_update.rs
@@ -36,7 +36,7 @@ pub fn update_route_departure(
     new_departure_time: Timestamp,
     state_keys: &ScheduleStateKeys,
 ) {
-    let mut start = route_ctx.route_mut().tour.get_mut(0).unwrap();
+    let start = route_ctx.route_mut().tour.get_mut(0).unwrap();
     start.schedule.departure = new_departure_time;
 
     update_route_schedule(route_ctx, activity, transport, state_keys);

--- a/vrp-core/src/solver/heuristic.rs
+++ b/vrp-core/src/solver/heuristic.rs
@@ -198,7 +198,7 @@ pub fn create_scalar_operator_probability(
     scalar_probability: f64,
     random: Arc<dyn Random + Send + Sync>,
 ) -> TargetHeuristicProbability {
-    (Box::new(move |_, _| random.is_hit(scalar_probability)), PhantomData::default())
+    (Box::new(move |_, _| random.is_hit(scalar_probability)), PhantomData)
 }
 
 /// Creates a heuristic operator probability which uses context state.
@@ -221,7 +221,7 @@ pub fn create_context_operator_probability(
             let phase_probability = phases.get(&refinement_ctx.selection_phase()).cloned().unwrap_or(0.);
             random.is_hit(phase_probability)
         }),
-        PhantomData::default(),
+        PhantomData,
     )
 }
 

--- a/vrp-pragmatic/src/format/solution/geo_serializer.rs
+++ b/vrp-pragmatic/src/format/solution/geo_serializer.rs
@@ -32,6 +32,12 @@ struct FeatureCollection {
     pub features: Vec<Feature>,
 }
 
+#[derive(Clone, Debug, Serialize, PartialEq)]
+struct FeatureCollectionWithSolution {
+    geo: FeatureCollection,
+    pragmatic: Solution,
+}
+
 impl Eq for Geometry {}
 
 impl PartialEq for Geometry {
@@ -80,6 +86,18 @@ pub fn serialize_solution_as_geojson<W: Write>(
     let geo_json = create_geojson_solution(problem, solution)?;
 
     serde_json::to_writer_pretty(writer, &geo_json).map_err(Error::from)
+}
+
+/// Serializes solution into pragmatic and geo json format.
+pub fn serialize_solution_with_geojson<W: Write>(
+    writer: &mut BufWriter<W>,
+    problem: &Problem,
+    solution: &Solution,
+) -> Result<(), Error> {
+    let geo = create_geojson_solution(problem, solution)?;
+    let combined = FeatureCollectionWithSolution { geo, pragmatic: solution.clone() };
+
+    serde_json::to_writer_pretty(writer, &combined).map_err(Error::from)
 }
 
 /// Serializes named location list with their color index.


### PR DESCRIPTION
Since the problem isn't serialized, but the solution serializer requires the problem, we can't transpile from pragmatic-json to geo-json after the fact as we can't deserialize any problem at this point. So as a quick fix,  instead, I attempt to write the two output formats under different json keys.

This is not really a good design and I just realize that maybe I'd actually [already have the problem at hand in the right format](https://github.com/reinterpretcat/vrp/blob/52c36edc96cb17e77df1bca544f8f833b3cf780a/examples/python-interop/example.py#L117). But that's for tomorrow. :smile:  