### PR TITLE
fix docs

### DIFF
--- a/docs/src/concepts/pragmatic/routing/format.md
+++ b/docs/src/concepts/pragmatic/routing/format.md
@@ -14,7 +14,7 @@ list, locations are specified in the order they defined. For example, if you hav
 vehicle type with depot location C, then you have the following location list: A,B,C. It corresponds to the matrix (durations
 or distances):
 
-|    |    |    |
+| <!-- --> | <!-- --> | <!-- --> |
 |----|----|----|
 |  0 | AB | AC |
 | BA |  0 | BC |


### PR DESCRIPTION
- docs: fix markdown matrix representation

**Prior**

![image](https://github.com/reinterpretcat/vrp/assets/7548295/390bae3d-6141-43f5-81a6-ad4706f6dde4)


**Now**

![image](https://github.com/reinterpretcat/vrp/assets/7548295/93acc419-a45f-4ab6-a9ba-8acddaa9be39)
