### PR TITLE
Corrected documentation of specifying multiple routing matrices

### DIFF
--- a/docs/src/concepts/pragmatic/routing/profile.md
+++ b/docs/src/concepts/pragmatic/routing/profile.md
@@ -31,7 +31,7 @@ each profile. It is optional, default value is `10` which corresponds to `10m/s`
 In general, you're not limited to one single routing profile. You can define multiple ones and pass their matrices
 to the solver:
 
-    vrp-cli solve pragmatic problem.json -m routing_matrix_car.json -m routing_matrix_truck.json
+    vrp-cli solve pragmatic problem.json -m routing_matrix_car.json routing_matrix_truck.json
 
 Make sure that for all profile names in `fleet.profiles` you have the corresponding matrix specified.
 

--- a/docs/src/examples/pragmatic/basics/profiles.md
+++ b/docs/src/examples/pragmatic/basics/profiles.md
@@ -53,7 +53,7 @@ This example demonstrates how to use multiple routing profiles: `car` and `truck
     <summary>Usage with cli</summary><p>
 
 ```
-vrp-cli solve pragmatic profiles.basic.problem.json -m profiles.basic.matrix.car.json -m profiles.basic.matrix.truck -o profiles.basic.solution.json
+vrp-cli solve pragmatic profiles.basic.problem.json -m profiles.basic.matrix.car.json profiles.basic.matrix.truck -o profiles.basic.solution.json
 ```
 
 </p></details>


### PR DESCRIPTION
Might be a change in clap library, but the currently documented way of using multiple routing matrices failed with an error:
"the argument '--matrix <matrix>...' cannot be used multiple times"

The working way of using multiple matrices is simply pass multiple file names separated by spaces after a "-m" switch.